### PR TITLE
Add warp template

### DIFF
--- a/templates/warp.yaml
+++ b/templates/warp.yaml
@@ -1,0 +1,26 @@
+name: Aether
+accent: "{color4}"
+cursor: "{color4}"
+background: "{background}"
+foreground: "{foreground}"
+details: darker
+
+terminal_colors:
+  normal:
+    black:   "{color0}"
+    red:     "{color1}"
+    green:   "{color2}"
+    yellow:  "{color3}"
+    blue:    "{color4}"
+    magenta: "{color5}"
+    cyan:    "{color6}"
+    white:   "{color7}"
+  bright:
+    black:   "{color8}"
+    red:     "{color9}"
+    green:   "{color10}"
+    yellow:  "{color11}"
+    blue:    "{color12}"
+    magenta: "{color13}"
+    cyan:    "{color14}"
+    white:   "{color15}"


### PR DESCRIPTION
Adds a Warp terminal template to Aether. This template generates a .yaml file compatible with Warp’s custom themes (~/.local/share/warp-terminal/themes/). 

Users can apply any Aether palette to the Warp theme seamlessly. But will have todo the symlink or mv themself for it to be useful.