### PR TITLE
gruvbox-material dark hard

### DIFF
--- a/src/constants/presets.js
+++ b/src/constants/presets.js
@@ -176,6 +176,28 @@ export const COLOR_PRESETS = [
         ],
     },
     {
+        name: 'Gruvbox Material Dark Hard',
+        author: 'Soft Contrast Gruvbox',
+        colors: [
+            '#1d2021',
+            '#ea6962',
+            '#a9b665',
+            '#d8a657',
+            '#7daea3',
+            '#d3869b',
+            '#89b482',
+            '#d4be98',
+            '#32302f',
+            '#ea6962',
+            '#a9b665',
+            '#d8a657',
+            '#7daea3',
+            '#d3869b',
+            '#89b482',
+            '#ddc7a1',
+        ],
+    },
+    {
         name: 'Solarized Dark',
         author: 'Precision Colors',
         colors: [


### PR DESCRIPTION
<img width="394" height="379" alt="image" src="https://github.com/user-attachments/assets/f9e61bea-4a6a-4947-bdc1-7c784761f0b1" />
