### PR TITLE
neovim plugin for gruvbox-material

### DIFF
--- a/src/constants/neovim-presets.js
+++ b/src/constants/neovim-presets.js
@@ -62,6 +62,26 @@ export const NEOVIM_PRESETS = [
 }`,
     },
     {
+        name: 'Gruvbox Material',
+        author: 'sainnhe',
+        config: `return {
+\t{
+\t\t"sainnhe/gruvbox-material",
+\t\tpriority = 1000,
+\t\tconfig = function()
+\t\t\tvim.g.gruvbox_material_background = "hard"
+\t\t\tvim.g.gruvbox_material_transparent_background = 1
+\t\tend,
+\t},
+\t{
+\t\t"LazyVim/LazyVim",
+\t\topts = {
+\t\t\tcolorscheme = "gruvbox-material",
+\t\t},
+\t},
+}`,
+    },
+    {
         name: 'Rose Pine',
         author: 'rose-pine',
         config: `return {


### PR DESCRIPTION
### Forgot to add the Neovim plugin when adding the preset.

<img width="404" height="405" alt="image" src="https://github.com/user-attachments/assets/3d851737-7cc7-4b24-8a4d-7a7356d5e838" />
