### PR TITLE
Clear Additional Images

### DIFF
--- a/src/components/PaletteEditor.js
+++ b/src/components/PaletteEditor.js
@@ -431,11 +431,15 @@ export const PaletteEditor = GObject.registerClass(
                 this.loadWallpaperWithoutExtraction(palette.wallpaper);
             }
 
+            // Always reset additional images when loading blueprint
+            // Then load blueprint's images if they exist
             if (
                 palette.additionalImages &&
                 Array.isArray(palette.additionalImages)
             ) {
                 this._additionalImages.setImages(palette.additionalImages);
+            } else {
+                this._additionalImages.reset();
             }
 
             if (palette.lightMode !== undefined) {


### PR DESCRIPTION
When loading a blueprint that doesn't have additionalImages defined, the previous additional images would remain visible. This commit ensures that additional images are always reset when loading a blueprint, and only populated if the blueprint contains them.

Changes:
- Added else clause to reset additional images when blueprint lacks them
- Ensures clean state when switching between blueprints
- Prevents stale additional images from previous blueprint

Fixes blueprint switching behavior for additional images.