### PR TITLE
Added gated purity filter boxes

### DIFF
--- a/src/components/WallpaperBrowser.js
+++ b/src/components/WallpaperBrowser.js
@@ -1276,14 +1276,6 @@ export const WallpaperBrowser = GObject.registerClass(
 
             apiGroup.add(apiKeyRow);
 
-            const puritySwitchRow = new Adw.SwitchRow({
-                title: 'Show purity filters',
-                subtitle:
-                    'Enable SFW/Sketchy/NSFW controls in the wallpaper browser',
-                active: currentPurityControlsEnabled,
-            });
-            apiGroup.add(puritySwitchRow);
-
             // Help text for API key
             const apiHelpLabel = new Gtk.Label({
                 label: 'Get your API key from:\nhttps://wallhaven.cc/settings/account',
@@ -1375,6 +1367,19 @@ export const WallpaperBrowser = GObject.registerClass(
             contentBox.append(resolutionGroup);
             contentBox.append(presetsBox);
             contentBox.append(resolutionHelpLabel);
+
+            const purityGroup = new Adw.PreferencesGroup({
+                title: 'Content Filters',
+            });
+
+            const puritySwitchRow = new Adw.SwitchRow({
+                title: 'Show purity filters',
+                subtitle:
+                    'Enable SFW/Sketchy/NSFW controls in the wallpaper browser',
+                active: currentPurityControlsEnabled,
+            });
+            purityGroup.add(puritySwitchRow);
+            contentBox.append(purityGroup);
 
             // Action buttons
             const buttonBox = new Gtk.Box({


### PR DESCRIPTION
Loving Aether so far! Would appreciate feedback and if this would even be considered. Thanks!

---

This PR adds configurable purity settings (100*/110/111) to the wallhaven settings and filter box. It gates the purity settings behind a configuration flag (see screenshots) and is disabled by default. If enabled without an API key, only default and 110/Sketchy filters are accessible if the config flag is switches, as 111/NSFW requires an API key.

#### Screenshots
<img width="626" height="660" alt="image" src="https://github.com/user-attachments/assets/ab8bc133-91b8-493b-a952-1d99851a38c2" />

<img width="766" height="130" alt="image" src="https://github.com/user-attachments/assets/6abfdc7a-f769-4c21-912f-f8f0b0442297" />


