### PR TITLE
Export additional images with theme backgrounds

### DIFF
--- a/src/AetherWindow.js
+++ b/src/AetherWindow.js
@@ -842,6 +842,7 @@ export const AetherWindow = GObject.registerClass(
             const wallpaperPath = themeState.getWallpaper();
             const lightMode = themeState.getLightMode();
             const appOverrides = themeState.getAppOverrides();
+            const additionalImages = themeState.getAdditionalImages();
             // Settings still from component
             const settings = this.settingsSidebar.getSettings();
 
@@ -850,7 +851,8 @@ export const AetherWindow = GObject.registerClass(
                 wallpaperPath,
                 settings,
                 lightMode,
-                appOverrides
+                appOverrides,
+                additionalImages
             );
             this.themeExporter.startExport();
         }

--- a/src/services/ThemeExporter.js
+++ b/src/services/ThemeExporter.js
@@ -32,7 +32,8 @@ export class ThemeExporter {
                 themeName,
                 this.settings,
                 this.lightMode,
-                this.appOverrides
+                this.appOverrides,
+                this.additionalImages
             );
 
             this.dialogManager.showSuccessDialog(fullPath);
@@ -41,11 +42,19 @@ export class ThemeExporter {
         }
     }
 
-    setThemeData(colors, wallpaper, settings, lightMode, appOverrides = {}) {
+    setThemeData(
+        colors,
+        wallpaper,
+        settings,
+        lightMode,
+        appOverrides = {},
+        additionalImages = []
+    ) {
         this.colors = colors;
         this.wallpaper = wallpaper;
         this.settings = settings;
         this.lightMode = lightMode;
         this.appOverrides = appOverrides;
+        this.additionalImages = additionalImages;
     }
 }

--- a/src/utils/ConfigWriter.js
+++ b/src/utils/ConfigWriter.js
@@ -553,7 +553,8 @@ export class ConfigWriter {
         themeName,
         settings = {},
         lightMode = false,
-        appOverrides = {}
+        appOverrides = {},
+        additionalImages = []
     ) {
         try {
             ensureDirectoryExists(exportPath);
@@ -566,6 +567,24 @@ export class ConfigWriter {
                 const destPath = GLib.build_filenamev([bgDir, fileName]);
                 copyFile(wallpaperPath, destPath);
                 console.log(`Copied wallpaper to: ${destPath}`);
+            }
+
+            if (additionalImages && additionalImages.length > 0) {
+                additionalImages.forEach((sourcePath, index) => {
+                    const fileName = GLib.path_get_basename(sourcePath);
+                    const destPath = GLib.build_filenamev([bgDir, fileName]);
+                    const success = copyFile(sourcePath, destPath);
+
+                    if (success) {
+                        console.log(
+                            `Copied additional image ${index + 1}: ${fileName}`
+                        );
+                    } else {
+                        console.error(
+                            `Failed to copy additional image: ${fileName}`
+                        );
+                    }
+                });
             }
 
             const variables = this._buildVariables(colorRoles, lightMode);


### PR DESCRIPTION
## Summary

  This PR updates theme export so additional images are included in the exported Omarchy
  theme package.

  Previously, export only copied the primary wallpaper into backgrounds/.
  Now, export also copies images from the editor’s Additional Images section into the
  same backgrounds/ directory.

  ## What Changed

  - src/AetherWindow.js
      - In _exportTheme(), read additional images from state:
          - themeState.getAdditionalImages()
      - Pass them into themeExporter.setThemeData(...).
  - src/services/ThemeExporter.js
      - Extended setThemeData(...) to accept/store additionalImages.
      - Forward additionalImages into configWriter.exportTheme(...).
  - src/utils/ConfigWriter.js
      - Extended exportTheme(...) signature with additionalImages = [].
      - Added copy step to place each additional image in:
          - <exportPath>/backgrounds/

  ## Behavior Notes

  - Backward compatible: callers that do not pass additional images continue to work ([]
    default).
  - Collision behavior is unchanged from existing apply/generate flows:
      - copy target uses basename, so duplicate filenames overwrite the earlier copy. (this is existing behavior, kept to minimize code changes in PR)

  ## Testing

  - Verified commit scope is limited to export pipeline files only.
  - Verified formatting checks pass in this environment.
  - Manual validation expected flow:
      1. Add main wallpaper + additional images in UI.
      2. Export theme.
      3. Confirm exported backgrounds/ contains primary wallpaper and additional images.

  ## Why

  This aligns export behavior with apply/generate expectations, so shared/exported themes
  preserve the full background set users configured in the UI.
