### PR TITLE
Add configurable GTK border-radius

### DIFF
--- a/frontend/src/lib/components/sidebar/TemplateToggles.svelte
+++ b/frontend/src/lib/components/sidebar/TemplateToggles.svelte
@@ -41,4 +41,26 @@
             </label>
         {/each}
     </div>
+    <div class="mt-3">
+        <label class="flex flex-col gap-0.5">
+            <span class="text-fg-secondary text-[11px]">GTK Border Radius</span
+            >
+            <select
+                class="bg-bg-surface border-border text-fg-primary w-full border px-1.5 py-1 text-[11px]"
+                value={getSettings().gtkBorderRadius}
+                onchange={(e) =>
+                    updateSettings({
+                        gtkBorderRadius: Number(
+                            (e.target as HTMLSelectElement).value,
+                        ),
+                    })}
+            >
+                <option value={0}>Sharp (0px)</option>
+                <option value={6}>Subtle (6px)</option>
+                <option value={12}>Rounded (12px)</option>
+                <option value={18}>More (18px)</option>
+                <option value={24}>Extra (24px)</option>
+            </select>
+        </label>
+    </div>
 </div>

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -6,6 +6,7 @@ const defaults: Settings = {
     includeVscode: false,
     includeNeovim: true,
     selectedNeovimConfig: '',
+    gtkBorderRadius: 0,
 };
 
 let settings = $state<Settings>({...defaults});

--- a/frontend/src/lib/types/theme.ts
+++ b/frontend/src/lib/types/theme.ts
@@ -44,6 +44,7 @@ export interface Settings {
     includeVscode: boolean;
     includeNeovim: boolean;
     selectedNeovimConfig: string;
+    gtkBorderRadius: number;
 }
 
 export const DEFAULT_ADJUSTMENTS: Adjustments = {

--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -2,6 +2,7 @@ package theme
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"log"
 	"path"
@@ -57,6 +58,9 @@ type Settings struct {
 	IncludeNeovim        bool            `json:"includeNeovim"`
 	SelectedNeovimConfig string          `json:"selectedNeovimConfig"`
 	ExcludedApps         map[string]bool `json:"excludedApps,omitempty"`
+	// GTK CSS customisation: border-radius in pixels.
+	// 0 means sharp corners (default, Hyprland-style).
+	GtkBorderRadius int `json:"gtkBorderRadius"`
 }
 
 // ApplyResult is returned by ApplyTheme with the outcome of theme application.
@@ -155,6 +159,7 @@ func (w *Writer) ApplyTheme(state *ThemeState, settings Settings) (*ApplyResult,
 	}
 
 	variables := template.BuildVariables(state.ColorRoles, state.LightMode)
+	variables["gtk_border_radius"] = fmt.Sprintf("%dpx", settings.GtkBorderRadius)
 	w.processTemplates(variables, themeDir, settings, state.AppOverrides)
 	w.applyAetherThemeOverride(variables, themeDir)
 	w.applyEditorThemes(themeDir, settings, variables)
@@ -199,6 +204,7 @@ func (w *Writer) GenerateOnly(state *ThemeState, settings Settings, outputPath s
 	}
 
 	variables := template.BuildVariables(state.ColorRoles, state.LightMode)
+	variables["gtk_border_radius"] = fmt.Sprintf("%dpx", settings.GtkBorderRadius)
 	w.processTemplates(variables, targetDir, settings, state.AppOverrides)
 
 	// Generate VSCode extension into the export directory

--- a/templates/gtk.css
+++ b/templates/gtk.css
@@ -177,8 +177,8 @@ toast button.circular.flat.image-button:hover {
     background-color: @red;
 }
 
-/* Sharp corners, Hyprland-inspired */
+/* Configurable border radius (set via Settings.GtkBorderRadius) */
 * {
-    border-radius: 0;
+    border-radius: {gtk_border_radius};
 }
 


### PR DESCRIPTION
Replaces the hardcoded `border-radius: 0` in _gtk.css_ with a `{gtk_border_radius}` template variable controlled by a new settings gtk field (default: 0px / sharp corners, as prev Hyprland inspired).

A dropdown in the Templates section lets users choose between _Sharp_ (0px), _Subtle_ (6px), _Rounded_ (12px), _More_ (18px), and _Extra_ (24px). The setting is persisted in _settings.json_.