### PR TITLE
Make Aether buildable on Debian/Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build dev test clean aether-wp install
 
 UNAME_S := $(shell uname -s)
+WEBKIT_TAGS := $(shell pkg-config --exists webkit2gtk-4.0 2>/dev/null || echo "-tags webkit2_41")
 
 aether-wp:
 ifeq ($(UNAME_S),Linux)
@@ -13,7 +14,7 @@ build:
 ifeq ($(UNAME_S),Linux)
 	$(MAKE) aether-wp
 endif
-	wails build
+	wails build $(WEBKIT_TAGS)
 
 install: build
 ifeq ($(UNAME_S),Darwin)
@@ -25,7 +26,7 @@ else
 endif
 
 dev:
-	wails dev
+	wails dev $(WEBKIT_TAGS)
 
 test:
 	go test ./internal/... ./cli/...

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,8 @@ sudo apt install golang libgtk-3-dev libwebkit2gtk-4.1-dev libgtk-layer-shell-de
   libgstreamer1.0-dev gstreamer1.0-plugins-good ffmpeg nodejs npm pkg-config
 ```
 
+> **Note:** Debian Bookworm and Ubuntu 22.04+ ship only `webkit2gtk-4.1`. The build system handles this automatically via the `-tags webkit2_41` flag, so no manual workaround is needed.
+
 ### Build
 
 ```bash


### PR DESCRIPTION
Wails v2 looks for _webkit2gtk-4.0_ via `pkg-config` by default, but Debian (12+) and Ubuntu (22.04+) no longer provides it. Only _webkit2gtk-4.1_ is supported.

This way, we can still build it on Debian and Ubuntu.