### PR TITLE
fix: use correct VS Code extension directory naming convention

### DIFF
--- a/internal/theme/applier_vscode.go
+++ b/internal/theme/applier_vscode.go
@@ -19,7 +19,7 @@ func ApplyVSCodeTheme(fsys embed.FS, templatesDir string, variables map[string]s
 		return err
 	}
 
-	extensionDir := filepath.Join(home, ".vscode", "extensions", "theme-aether")
+	extensionDir := filepath.Join(home, ".vscode", "extensions", "local.theme-aether-1.0.0")
 	if err := platform.EnsureDir(extensionDir); err != nil {
 		return err
 	}
@@ -28,6 +28,6 @@ func ApplyVSCodeTheme(fsys embed.FS, templatesDir string, variables map[string]s
 		return err
 	}
 
-	log.Printf("VSCode theme extension installed to: %s", extensionDir)
+	log.Printf("VS Code theme extension installed to: %s", extensionDir)
 	return nil
 }


### PR DESCRIPTION
## Problem

VS Code expects extensions in `~/.vscode/extensions/<publisher>.<name>-<version>/` format. The current path `theme-aether` is not recognized by VS Code, causing the locally-installed Aether theme to be silently ignored.

## Fix

Change the extension directory from `theme-aether` to `local.theme-aether-1.0.0` to match the `package.json` fields (publisher: `local`, name: `theme-aether`, version: `1.0.0`).

## Testing

1. Install Aether from source with this fix
2. Apply a theme in Aether
3. The VS Code theme should now appear in the theme picker without needing to manually rename the directory

Fixes #108