### PR TITLE
Fix: copy additional wallpapers when applying blueprint via CLI

### DIFF
--- a/cli/blueprints.go
+++ b/cli/blueprints.go
@@ -113,11 +113,12 @@ func runApplyBlueprint(args []string, templatesFS embed.FS) int {
 
 	writer := theme.NewWriter(templatesFS, "templates")
 	state := &theme.ThemeState{
-		Palette:       palette,
-		WallpaperPath: wallpaperPath,
-		LightMode:     lightMode,
-		ColorRoles:    colorRoles,
-		AppOverrides:  bp.AppOverrides,
+		Palette:          palette,
+		WallpaperPath:    wallpaperPath,
+		LightMode:        lightMode,
+		ColorRoles:       colorRoles,
+		AppOverrides:     bp.AppOverrides,
+		AdditionalImages: bp.Palette.AdditionalImages,
 	}
 
 	settings := theme.DefaultApplySettings()


### PR DESCRIPTION
## What

When applying a blueprint via `aether --apply-blueprint`, only the main
wallpaper is copied to the theme's `backgrounds/` folder. Additional
wallpapers (stored in `blueprint.Palette.AdditionalImages`) are silently
skipped.

## Why

In `cli/blueprints.go`, `runApplyBlueprint` constructs a `ThemeState`
without assigning `AdditionalImages`:

    state := &theme.ThemeState{
        Palette:       palette,
        WallpaperPath: wallpaperPath,
        LightMode:     lightMode,
        ColorRoles:    colorRoles,
        AppOverrides:  bp.AppOverrides,
        // AdditionalImages missing
    }

The GUI path in `app.go` (`ApplyBlueprint`, line 503) already handles
this correctly:

    if bp.Palette.AdditionalImages != nil {
        a.state.AdditionalImages = bp.Palette.AdditionalImages
    } else {
        a.state.AdditionalImages = []string{}
    }

The writer's `prepareThemeDir` in `internal/theme/writer.go` already
iterates and copies `AdditionalImages` correctly — the CLI path just
never populated the field.

## Fix

Add the missing field assignment to `runApplyBlueprint` in
`cli/blueprints.go`, mirroring the GUI path.