### PR TITLE
Fix: preserve blueprint extended colors when applying blueprints

### DIFF
--- a/app.go
+++ b/app.go
@@ -469,6 +469,13 @@ func (a *App) LoadBlueprint(name string) error {
 	for i := 0; i < 16 && i < len(bp.Palette.Colors); i++ {
 		palette[i] = bp.Palette.Colors[i]
 	}
+
+	if bp.Palette.ExtendedColors != nil {
+		a.state.ExtendedColors = bp.Palette.ExtendedColors
+	} else {
+		a.state.ExtendedColors = map[string]string{}
+	}
+
 	a.state.SetPalette(palette)
 	a.state.WallpaperPath = a.resolveWallpaper(bp.Palette)
 	a.state.LightMode = bp.Palette.LightMode
@@ -495,6 +502,12 @@ func (a *App) ApplyBlueprint(name string) (*theme.ApplyResult, error) {
 	var palette [16]string
 	for i := 0; i < 16 && i < len(bp.Palette.Colors); i++ {
 		palette[i] = bp.Palette.Colors[i]
+	}
+
+	if bp.Palette.ExtendedColors != nil {
+		a.state.ExtendedColors = bp.Palette.ExtendedColors
+	} else {
+		a.state.ExtendedColors = map[string]string{}
 	}
 
 	a.state.SetPalette(palette)

--- a/cli/blueprints.go
+++ b/cli/blueprints.go
@@ -108,16 +108,31 @@ func runApplyBlueprint(args []string, templatesFS embed.FS) int {
 	}
 
 	colorRoles := MapColorsToRoles(palette)
+
+	if v := bp.Palette.ExtendedColors["accent"]; v != "" {
+		colorRoles.Accent = v
+	}
+	if v := bp.Palette.ExtendedColors["cursor"]; v != "" {
+		colorRoles.Cursor = v
+	}
+	if v := bp.Palette.ExtendedColors["selection_foreground"]; v != "" {
+		colorRoles.SelectionForeground = v
+	}
+	if v := bp.Palette.ExtendedColors["selection_background"]; v != "" {
+		colorRoles.SelectionBackground = v
+	}
+
 	lightMode := bp.Palette.LightMode
 	wallpaperPath := resolveWallpaperCLI(bp.Palette)
 
 	writer := theme.NewWriter(templatesFS, "templates")
 	state := &theme.ThemeState{
-		Palette:       palette,
-		WallpaperPath: wallpaperPath,
-		LightMode:     lightMode,
-		ColorRoles:    colorRoles,
-		AppOverrides:  bp.AppOverrides,
+		Palette:        palette,
+		WallpaperPath:  wallpaperPath,
+		LightMode:      lightMode,
+		ColorRoles:     colorRoles,
+		ExtendedColors: bp.Palette.ExtendedColors,
+		AppOverrides:   bp.AppOverrides,
 	}
 
 	settings := theme.DefaultApplySettings()


### PR DESCRIPTION
## Summary

This fixes blueprint application so manually configured extended colors are preserved when loading or applying a blueprint.

Previously, blueprint files could store `palette.extendedColors`, but applying a blueprint rebuilt the theme color roles without restoring those values into state first. As a result, values like `accent`, `cursor`, `selection_foreground`, and `selection_background` fell back to generated defaults.

## Changes

- Restore `bp.Palette.ExtendedColors` before rebuilding color roles in the app blueprint load/apply path.
- Apply stored extended colors in the CLI blueprint apply path.

## Testing

Tested locally by applying a blueprint with custom extended colors:

```json
"extendedColors": {
  "accent": "#ff00aa",
  "cursor": "#00ffaa",
  "selection_foreground": "#111111",
  "selection_background": "#ffee00"
}
```
Confirmed the generated `colors.toml` contains the custom values instead of the default generated values.
